### PR TITLE
Changed integers to variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "ecs" {
   private_subnets     = slice(module.network.private_subnets, 0, 2)
 
   desired_count = 1
+  port          = 3000
   memory        = 512
   cpu           = 256
 

--- a/modules/ecs/container-definition.json
+++ b/modules/ecs/container-definition.json
@@ -5,11 +5,11 @@
         "portMappings": [
             {
                 "protocol": "tcp",
-                "containerPort": 3000
+                "containerPort": "${port}"
             }
         ],
-        "memory": 512,
-        "cpu": 256,
+        "memory": "${memory}",
+        "cpu": "${cpu}",
         "requiresCompatibilities": [
         "FARGATE"
         ],

--- a/modules/ecs/container-definition.json
+++ b/modules/ecs/container-definition.json
@@ -5,11 +5,11 @@
         "portMappings": [
             {
                 "protocol": "tcp",
-                "containerPort": "${port}"
+                "containerPort": ${port}
             }
         ],
-        "memory": "${memory}",
-        "cpu": "${cpu}",
+        "memory": ${memory},
+        "cpu": ${cpu},
         "requiresCompatibilities": [
         "FARGATE"
         ],

--- a/modules/ecs/ecs.tf
+++ b/modules/ecs/ecs.tf
@@ -7,8 +7,8 @@ resource "aws_security_group" "weather_app_ecs_sg" {
   ingress = [
     {
       description      = "ECS"
-      from_port        = 3000
-      to_port          = 3000
+      from_port        = var.port
+      to_port          = var.port
       protocol         = "tcp"
       security_groups  = [var.alb_sg_id]
       cidr_blocks      = []

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -4,5 +4,8 @@ locals {
     name_prefix         = var.name_prefix
     ecr-repo-uri        = var.ecr_repo_uri
     execution-role-arn  = var.ecs_iam_role_arn
+    port                = var.port
+    memory              = var.memory
+    cpu                 = var.cpu
   })
 }

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -32,6 +32,10 @@ variable "desired_count" {
   type        = number
 }
 
+variable "port" {
+  type        = number
+}
+
 variable "memory" {
   type        = number
 }


### PR DESCRIPTION
Currently failing

```
Error: ECS Task Definition container_definitions is invalid: Error decoding JSON: json: cannot unmarshal string into Go struct field PortMapping.PortMappings.ContainerPort of type int64
│ 
│   with module.ecs.aws_ecs_task_definition.task_definition,
│   on modules/ecs/ecs.tf line 49, in resource "aws_ecs_task_definition" "task_definition":
│   49:     container_definitions   = local.container_definitions
```